### PR TITLE
API de comunicação com o Radar Legislativo

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,6 @@
-KEYWORDS=acesso, gênero, liberdade de expressão, privacidade, inovação, direito do consumidor
-START_DATE=2018-01-01
 MEMCACHED_LOCATION=localhost:11211
+RADAR_API_URL=http://localhost:8000/api/projeto/novo/
+RASPADOR_API_TOKEN=chave-da-api
+
+START_DATE=2015-01-01
+KEYWORDS=acesso, gênero, liberdade de expressão, privacidade, inovação, direito do consumidor

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 MEMCACHED_LOCATION=localhost:11211
-RADAR_API_URL=http://localhost:8000/api/projeto/novo/
+RASPADOR_API_URL=http://localhost:8000/api/projeto/novo/
 RASPADOR_API_TOKEN=chave-da-api
 
 START_DATE=2015-01-01

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .env
 .scrapy/
+.pytest_cache/
 __pycache__/
 data/*.csv

--- a/Pipfile
+++ b/Pipfile
@@ -10,9 +10,12 @@ python_version = "3.6"
 PyPDF2 = "*"
 python-decouple = "*"
 python-memcached = "*"
+requests = "*"
 scrapy = "*"
 scrapy-memcached-cache = "*"
 
 [dev-packages]
 ipdb = "*"
 ipython = "*"
+pytest = "*"
+pytest-mock = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8ee82802fe1b3b4894f535c2b57e83cb598ee25458591dcd7da4ec883b37f8a0"
+            "sha256": "dea61d301b3bb917ce611810af4d95684787e2ec07876fcf9086e52e2a84b8f9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,15 +37,25 @@
             ],
             "version": "==0.7.0"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+            ],
+            "version": "==2018.4.16"
+        },
         "cffi": {
             "hashes": [
                 "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
                 "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
                 "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
                 "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
+                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
                 "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
                 "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
+                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
                 "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
+                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
                 "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
                 "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
                 "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
@@ -54,11 +64,13 @@
                 "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
                 "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
                 "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
+                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
                 "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
                 "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
                 "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
                 "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
                 "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
+                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
                 "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
                 "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
                 "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
@@ -67,8 +79,15 @@
                 "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
                 "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
             ],
-            "markers": "platform_python_implementation != 'pypy'",
+            "markers": "platform_python_implementation != 'PyPy'",
             "version": "==1.11.5"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
         },
         "constantly": {
             "hashes": [
@@ -80,9 +99,11 @@
         "cryptography": {
             "hashes": [
                 "sha256:3f3b65d5a16e6b52fba63dc860b62ca9832f51f1a2ae5083c78b6840275f12dd",
+                "sha256:5251e7de0de66810833606439ca65c9b9e45da62196b0c88bfadf27740aac09f",
                 "sha256:551a3abfe0c8c6833df4192a63371aa2ff43afd8f570ed345d31f251d78e7e04",
                 "sha256:5cb990056b7cadcca26813311187ad751ea644712022a3976443691168781b6f",
                 "sha256:60bda7f12ecb828358be53095fc9c6edda7de8f1ef571f96c00b2363643fa3cd",
+                "sha256:64b5c67acc9a7c83fbb4b69166f3105a0ab722d27934fac2cb26456718eec2ba",
                 "sha256:6fef51ec447fe9f8351894024e94736862900d3a9aa2961528e602eb65c92bdb",
                 "sha256:77d0ad229d47a6e0272d00f6bf8ac06ce14715a9fd02c9a97f5a2869aab3ccb2",
                 "sha256:808fe471b1a6b777f026f7dc7bd9a4959da4bfab64972f2bbe91e22527c1c037",
@@ -104,6 +125,7 @@
                 "sha256:066d8bc5229af09617e24b3ca4d52f1f9092d9e061931f4184cd572885c23204",
                 "sha256:3b5103e8789da9e936a68d993b70df732d06b8bb9a337a05ed4eb52c17ef7206"
             ],
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==1.0.3"
         },
         "hyperlink": {
@@ -129,35 +151,34 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:01b194561b6a25d94b1267b785d6ec67eec6b62cce2591f3096de98ec22a704b",
-                "sha256:10ad7277b618b9a0bafed7ddf73af6d9c9b3de8d42cbb881859d611d54de665c",
-                "sha256:1fc9e6adc16c0cab2596de5cd7adc5988635ec1e2dcae367e2a2009302ae89b3",
-                "sha256:34cb8e68be4403d01a84f5dd5b9a089ddaedf28a3e9ff259708d88f9a60e2b7e",
-                "sha256:36a47fb5d99f7827cb478cc71f907b728304ead3b12b0eb1a102199a0a0bf8a7",
-                "sha256:37cda88cf6082fd9d78988156140a5922d4b296577b5ff83f72116c4061d7304",
-                "sha256:39e80bafa7be141ff2d0bb8ed1652b9ac326573bf0e6678770d729adbd9d2670",
-                "sha256:4211c2ff1a465d9bafc671715d40695bfeb59065005a8b565069b4ab3faba5d9",
-                "sha256:473ad409306e83dca68632bf29e1b40592b159af86318410ac42e8054f2904b8",
-                "sha256:482da759ec33fb78e3781d1c59aafa39a83265bbc796967f830d64d08f7212ad",
-                "sha256:48cccd8ba29c4cc967cb0e3317c5931e0f0ade1692895da6ba9a5a31410d75af",
-                "sha256:4b487bf101ce0217afcc3eb661713b32f10d30f1cac1e9d966f0a988ea8a389c",
-                "sha256:512f1b88f46ef1e55cb05150b8e7029be1c10995c3531d6c1205afa8b61d8996",
-                "sha256:73e23a2dd19d8f3c012cf6d3b221b32bf2254de49dfed449b2b87dd8fa56611e",
-                "sha256:810934dddb01a797fcd8ec9d9e981b8ebc7738ae1a5bbd2c90c7cdae5435609e",
-                "sha256:82f278cd24da1b8a98df89de38946d67381a00e39adef768fd302dc8f4e1c383",
-                "sha256:852d077b69432ad3c2ee622d4a82588fc32c8f260d41ce1a34207e60213b04a1",
-                "sha256:8eee7864ea7882512bada274c2a58997a09fa8da5f8a31e298ebf7226df0cf75",
-                "sha256:967ac7c857b4c67dbc906e2c7d81f89c14ea84d63adf4e95c6a1c9ed1bec2d77",
-                "sha256:a8b8c161d9dab9e884f99e7d898f6e06db547a3a0398962b55de96130b6da777",
-                "sha256:a9368022ca262fd15625f365b557d66ce0743bc1e1901d85dfe1af9836f01713",
-                "sha256:ab5ab5df9589a4538c238cf3711978419562ccf9c72efc06fb2f5e3833b7e0f4",
-                "sha256:be1d3c858071d552aab304742726ea1b3a46f21761f2c2a7afa93a37e57597f5",
-                "sha256:bea02d0662709d905bc18402ad4b84c5a6dc72d9d86dbbe9958eadf3d158e63b",
-                "sha256:d06bbb503f9e41c836a1941d163469b6df2f77f004bff609849f58ed52fa2ad4",
-                "sha256:d2965ef3521bcc3c82bd218a44f4c1f2630c127b5e1f35da50cb360e872bc3af",
-                "sha256:d78d58d934a3c2f39daaf89aad5e71551ff75550cf4820020ad6ae29f1b82cc9"
+                "sha256:0941f4313208c07734410414d8308812b044fd3fb98573454e3d3a0d2e201f3d",
+                "sha256:0b18890aa5730f9d847bc5469e8820f782d72af9985a15a7552109a86b01c113",
+                "sha256:21f427945f612ac75576632b1bb8c21233393c961f2da890d7be3927a4b6085f",
+                "sha256:24cf6f622a4d49851afcf63ac4f0f3419754d4e98a7a548ab48dd03c635d9bd3",
+                "sha256:2dc6705486b8abee1af9e2a3761e30a3cb19e8276f20ca7e137ee6611b93707c",
+                "sha256:2e43b2e5b7d2b9abe6e0301eef2c2c122ab45152b968910eae68bdee2c4cfae0",
+                "sha256:329a6d8b6d36f7d6f8b6c6a1db3b2c40f7e30a19d3caf62023c9d6a677c1b5e1",
+                "sha256:423cde55430a348bda6f1021faad7235c2a95a6bdb749e34824e5758f755817a",
+                "sha256:4651ea05939374cfb5fe87aab5271ed38c31ea47997e17ec3834b75b94bd9f15",
+                "sha256:4be3bbfb2968d7da6e5c2cd4104fc5ec1caf9c0794f6cae724da5a53b4d9f5a3",
+                "sha256:622f7e40faef13d232fb52003661f2764ce6cdef3edb0a59af7c1559e4cc36d1",
+                "sha256:664dfd4384d886b239ef0d7ee5cff2b463831079d250528b10e394a322f141f9",
+                "sha256:697c0f58ac637b11991a1bc92e07c34da4a72e2eda34d317d2c1c47e2f24c1b3",
+                "sha256:6ec908b4c8a4faa7fe1a0080768e2ce733f268b287dfefb723273fb34141475f",
+                "sha256:7ec3fe795582b75bb49bb1685ffc462dbe38d74312dac07ce386671a28b5316b",
+                "sha256:8c39babd923c431dcf1e5874c0f778d3a5c745a62c3a9b6bd755efd489ee8a1d",
+                "sha256:949ca5bc56d6cb73d956f4862ba06ad3c5d2808eac76304284f53ae0c8b2334a",
+                "sha256:9f0daddeefb0791a600e6195441910bdf01eac470be596b9467e6122b51239a6",
+                "sha256:a359893b01c30e949eae0e8a85671a593364c9f0b8162afe0cb97317af0953bf",
+                "sha256:ad5d5d8efed59e6b1d4c50c1eac59fb6ecec91b2073676af1e15fc4d43e9b6c5",
+                "sha256:bc1a36f95a6b3667c09b34995fc3a46a82e4cf0dc3e7ab281e4c77b15bd7af05",
+                "sha256:be37b3f55b6d7d923f43bf74c356fc1878eb36e28505f38e198cb432c19c7b1a",
+                "sha256:c45bca5e544eb75f7500ffd730df72922eb878a2f0213b0dc5a5f357ded3a85d",
+                "sha256:ccee7ebbb4735ebc341d347fca9ee09f2fa6c0580528c1414bc4e1d31372835c",
+                "sha256:dc62c0840b2fc7753550b40405532a3e125c0d3761f34af948873393aa688160",
+                "sha256:f7d9d5aa1c7e54167f1a3cba36b5c52c7c540f30952c9bd7d9302a1eda318424"
             ],
-            "version": "==4.2.2"
+            "version": "==4.2.3"
         },
         "parsel": {
             "hashes": [
@@ -168,37 +189,17 @@
         },
         "pyasn1": {
             "hashes": [
-                "sha256:2f57960dc7a2820ea5a1782b872d974b639aa3b448ac6628d1ecc5d0fe3986f2",
-                "sha256:3651774ca1c9726307560792877db747ba5e8a844ea1a41feb7670b319800ab3",
-                "sha256:602fda674355b4701acd7741b2be5ac188056594bf1eecf690816d944e52905e",
-                "sha256:8fb265066eac1d3bb5015c6988981b009ccefd294008ff7973ed5f64335b0f2d",
-                "sha256:9334cb427609d2b1e195bb1e251f99636f817d7e3e1dffa150cb3365188fb992",
-                "sha256:9a15cc13ff6bf5ed29ac936ca941400be050dff19630d6cd1df3fb978ef4c5ad",
                 "sha256:a66dcda18dbf6e4663bde70eb30af3fc4fe1acb2d14c4867a861681887a5f9a2",
-                "sha256:ba77f1e8d7d58abc42bfeddd217b545fdab4c1eeb50fd37c2219810ad56303bf",
-                "sha256:cdc8eb2eaafb56de66786afa6809cd9db2df1b3b595dcb25aa5b9dc61189d40a",
-                "sha256:d01fbba900c80b42af5c3fe1a999acf61e27bf0e452e0f1ef4619065e57622da",
-                "sha256:f281bf11fe204f05859225ec2e9da7a7c140b65deccd8a4eb0bc75d0bd6949e0",
                 "sha256:fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc"
             ],
             "version": "==0.4.3"
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:041e9fbafac548d095f5b6c3b328b80792f006196e15a232b731a83c93d59493",
-                "sha256:0cdca76a68dcb701fff58c397de0ef9922b472b1cb3ea9695ca19d03f1869787",
-                "sha256:0cea139045c38f84abaa803bcb4b5e8775ea12a42af10019d942f227acc426c3",
-                "sha256:0f2e50d20bc670be170966638fa0ae603f0bc9ed6ebe8e97a6d1d4cef30cc889",
-                "sha256:47fb6757ab78fe966e7c58b2030b546854f78416d653163f0ce9290cf2278e8b",
-                "sha256:598a6004ec26a8ab40a39ea955068cf2a3949ad9c0030da970f2e1ca4c9f1cc9",
-                "sha256:72fd8b0c11191da088147c6e4678ec53e573923ecf60b57eeac9e97433e09fc2",
-                "sha256:854700bbdd01394e2ada9c1bfbd0ed9f5d0c551350dbbd023e88b11d2771ae06",
-                "sha256:af00ea8f2022b6287dc375b2c70f31ab5af83989fc6fe9eacd4976ce26cd7ccc",
-                "sha256:b1f395cae2d669e0830cb023aa86f9f283b7a9aa32317d7f80d8e78aa2745812",
-                "sha256:c6747146e95d2b14cc2a8399b2b0bde3f93778f8f9ec704690d2b589c376c137",
-                "sha256:f53fe5bcebdf318f51399b250fe8325ef3a26d927f012cc0c8e0f9e9af7f9deb"
+                "sha256:a0cf3e1842e7c60fde97cb22d275eb6f9524f5c5250489e292529de841417547",
+                "sha256:a38a8811ea784c0136abfdba73963876328f66172db21a05a82f9515909bfb4e"
             ],
-            "version": "==0.2.1"
+            "version": "==0.2.2"
         },
         "pycparser": {
             "hashes": [
@@ -249,6 +250,14 @@
             ],
             "version": "==1.5.0"
         },
+        "requests": {
+            "hashes": [
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+            ],
+            "index": "pypi",
+            "version": "==2.19.1"
+        },
         "scrapy": {
             "hashes": [
                 "sha256:08d86737c560dcc1c4b73ac0ac5bd8d14b3e2265c1f7b195f0b73ab13741fe03",
@@ -259,10 +268,10 @@
         },
         "scrapy-memcached-cache": {
             "hashes": [
-                "sha256:0e802e47c12352b648c0853a7ccd103f515631084441e15e6c2e1a457b2f5131"
+                "sha256:fbc8b3649fde268b046e85bbcfbf475563a95b166be30612181a5443d68feec5"
             ],
             "index": "pypi",
-            "version": "==0.0.2"
+            "version": "==0.0.3"
         },
         "service-identity": {
             "hashes": [
@@ -283,7 +292,15 @@
                 "sha256:3ad1e553c7b66a501abbcf7736620210cc58928730d3e1b905b345fc30043d4b",
                 "sha256:a4cc164a781859c74de47f17f0e85f4bce8a3321a9d0892c015c8f80c4158ad9"
             ],
+            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==18.4.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+            ],
+            "version": "==1.23"
         },
         "w3lib": {
             "hashes": [
@@ -304,10 +321,25 @@
                 "sha256:e881ef610ff48aece2f4ee2af03d2db1a146dc7c705561bd6089b2356f61641f",
                 "sha256:f41037260deaacb875db250021fe883bf536bf6414a4fd25b25059b02e31b120"
             ],
+            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==4.5.0"
         }
     },
     "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+            ],
+            "version": "==1.1.5"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+            ],
+            "version": "==18.1.0"
+        },
         "backcall": {
             "hashes": [
                 "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
@@ -346,17 +378,25 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:1972f694c6bc66a2fac8718299e2ab73011d653a6d8059790c3476d2353b99ad",
-                "sha256:5861f6dc0c16e024cbb0044999f9cf8013b292c05f287df06d3d991a87a4eb89"
+                "sha256:b409ed0f6913a701ed474a614a3bb46e6953639033e31f769ca7581da5bd1ec1",
+                "sha256:c254b135fb39ad76e78d4d8f92765ebc9bf92cbc76f49e97ade1d5f5121e1f6f"
             ],
-            "version": "==0.12.0"
+            "version": "==0.12.1"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
+                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+            ],
+            "version": "==4.2.0"
         },
         "parso": {
             "hashes": [
-                "sha256:cdef26e8adc10d589f3ec4eb444bd0a29f3f1eb6d72a4292ab8afcb9d68976a6",
-                "sha256:f0604a40b96e062b0fd99cf134cc2d5cdf66939d0902f8267d938b0d5b26707f"
+                "sha256:8105449d86d858e53ce3e0044ede9dd3a395b1c9716c696af8aa3787158ab806",
+                "sha256:d250235e52e8f9fc5a80cc2a5f804c9fefd886b2e67a2b1099cf085f403f8e33"
             ],
-            "version": "==0.2.1"
+            "version": "==0.3.0"
         },
         "pexpect": {
             "hashes": [
@@ -373,6 +413,14 @@
             ],
             "version": "==0.7.4"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+            ],
+            "version": "==0.6.0"
+        },
         "prompt-toolkit": {
             "hashes": [
                 "sha256:1df952620eccb399c53ebb359cc7d9a8d3a9538cb34c5a1344bdbeb29fbcc381",
@@ -388,12 +436,36 @@
             ],
             "version": "==0.6.0"
         },
+        "py": {
+            "hashes": [
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+            ],
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*'",
+            "version": "==1.5.4"
+        },
         "pygments": {
             "hashes": [
                 "sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d",
                 "sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
             ],
             "version": "==2.2.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d754406c",
+                "sha256:90898786b3d0b880b47645bae7b51aa9bbf1e9d1e4510c2cfd15dd65c70ea0cd"
+            ],
+            "index": "pypi",
+            "version": "==3.6.2"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:53801e621223d34724926a5c98bd90e8e417ce35264365d39d6c896388dcc928",
+                "sha256:d89a8209d722b8307b5e351496830d5cc5e192336003a485443ae9adeb7dd4c0"
+            ],
+            "index": "pypi",
+            "version": "==1.10.0"
         },
         "simplegeneric": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ $ docker-compose up
 
 Verifique o resultado no diretótio `data/`.
 
+### Testes
+
+```sh
+docker-compose run --rm camara py.test
+```
+
 ## Instalação local (sem Docker)
 
 Requer [Python](https://python.org) 3.6 com [Pipenv](https://docs.pipenv.org/).
@@ -42,3 +48,9 @@ $ scrapy crawl senado
 ```
 
 Verifique o resultado no diretótio `data/`.
+
+### Testes
+
+```sh
+py.test
+```

--- a/raspadorlegislativo/items.py
+++ b/raspadorlegislativo/items.py
@@ -8,7 +8,10 @@
 import scrapy
 
 
-class RaspadorlegislativoItem(scrapy.Item):
-    # define the fields for your item here like:
-    # name = scrapy.Field()
-    pass
+class Bill(scrapy.Item):
+    nome = scrapy.Field()
+    id_site = scrapy.Field()
+    apresentacao = scrapy.Field()
+    ementa = scrapy.Field()
+    url = scrapy.Field()
+    match = scrapy.Field()

--- a/raspadorlegislativo/items.py
+++ b/raspadorlegislativo/items.py
@@ -1,17 +1,14 @@
-# -*- coding: utf-8 -*-
-
-# Define here the models for your scraped items
-#
-# See documentation in:
-# https://doc.scrapy.org/en/latest/topics/items.html
-
-import scrapy
+from scrapy import Field, Item
 
 
-class Bill(scrapy.Item):
-    nome = scrapy.Field()
-    id_site = scrapy.Field()
-    apresentacao = scrapy.Field()
-    ementa = scrapy.Field()
-    url = scrapy.Field()
-    match = scrapy.Field()
+class Bill(Item):
+    nome = Field()
+    id_site = Field()
+    apresentacao = Field()
+    ementa = Field()
+    autoria = Field()
+    local = Field()
+    origem = Field()
+
+    url = Field()
+    match = Field()

--- a/raspadorlegislativo/settings.py
+++ b/raspadorlegislativo/settings.py
@@ -66,9 +66,9 @@ DOWNLOADER_MIDDLEWARES = {
 
 # Configure item pipelines
 # See https://doc.scrapy.org/en/latest/topics/item-pipeline.html
-#ITEM_PIPELINES = {
-#    'raspadorlegislativo.pipelines.RaspadorlegislativoPipeline': 300,
-#}
+ITEM_PIPELINES = {
+    'raspadorlegislativo.pipelines.RaspadorlegislativoPipeline': 300,
+}
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://doc.scrapy.org/en/latest/topics/autothrottle.html
@@ -89,8 +89,13 @@ HTTPCACHE_ENABLED = True
 HTTPCACHE_EXPIRATION_SECS = 3 * 60 * 60  # 3 hours
 HTTPCACHE_IGNORE_HTTP_CODES = []
 HTTPCACHE_STORAGE = 'scrapy_memcached_cache.MemcachedCacheStorage'
+MEMCACHED_LOCATION = config('MEMCACHED_LOCATION')
 
+# Settings for Scrapy to filter and save bills
 KEYWORDS = config('KEYWORDS', cast=Keyword())
 START_DATE = config('START_DATE')
 FEED_FORMAT = 'csv'
-MEMCACHED_LOCATION = config('MEMCACHED_LOCATION')
+
+# Settings to communicate with Radar Legislativo API
+RASPADOR_API_URL = config('RASPADOR_API_URL', default=None)
+RASPADOR_API_TOKEN = config('RASPADOR_API_TOKEN', default=None)

--- a/raspadorlegislativo/spiders/__init__.py
+++ b/raspadorlegislativo/spiders/__init__.py
@@ -8,6 +8,7 @@ from scrapy import Spider as OriginalSpider
 from memcache import Client
 
 from raspadorlegislativo import settings
+from raspadorlegislativo.items import Bill
 from raspadorlegislativo.utils.pdf import extract_text
 
 
@@ -48,7 +49,7 @@ class Spider(OriginalSpider):
 
         if data['match']:
             data.pop('pending_requests')
-            yield data
+            yield Bill(data)
 
     def parse_pdf(self, uuid, response):
         _, tmp = mkstemp(suffix='.pdf')

--- a/raspadorlegislativo/spiders/__init__.py
+++ b/raspadorlegislativo/spiders/__init__.py
@@ -1,23 +1,65 @@
 import os
+from collections import namedtuple
+from functools import partial
 from tempfile import mkstemp
+from uuid import uuid4
 
-from scrapy import Spider
+from scrapy import Spider as OriginalSpider
+from memcache import Client
 
 from raspadorlegislativo import settings
 from raspadorlegislativo.utils.pdf import extract_text
 
 
-class Spider(Spider):
+PendingRequest = namedtuple('PendingRequest', ('request', 'url', 'callback'))
 
-    def parse_pdf(self, data, response):
+
+class Spider(OriginalSpider):
+
+    def __init__(self):
+        self.cache = Client((settings.MEMCACHED_LOCATION,))
+
+    def get_unique_id(self):
+        return str(uuid4()).encode()
+
+    def set_bill(self, uuid, data):
+        return self.cache.set(uuid, data, 60 * 60 * 3)
+
+    def get_bill(self, uuid):
+        return self.cache.get(uuid)
+
+    def has_pending_request(self, uuid):
+        data = self.get_bill(uuid)
+        return bool(data.get('pending_requests'))
+
+    def process_pending_requests(self, uuid):
+        data = self.get_bill(uuid)
+        while self.has_pending_request(uuid):
+            next_request, *pending_requests = data['pending_requests']
+            data['pending_requests'] = pending_requests
+            self.set_bill(uuid, data)
+
+            yield next_request.request(
+                url=next_request.url,
+                callback=partial(getattr(self, next_request.callback), uuid)
+            )
+
+            data = self.get_bill(uuid)
+
+        if data['match']:
+            data.pop('pending_requests')
+            yield data
+
+    def parse_pdf(self, uuid, response):
         _, tmp = mkstemp(suffix='.pdf')
         with open(tmp, 'wb') as fobj:
             fobj.write(response.body)
-
         text = extract_text(tmp).lower()
+
+        data = self.get_bill(uuid)
         for keyword in settings.KEYWORDS:
             if keyword in text:
-                yield data
-                break  # we don't need to collect the same item twice
+                data['match'].add(keyword)
 
         os.remove(tmp)
+        self.set_bill(uuid, data)

--- a/raspadorlegislativo/spiders/camara.py
+++ b/raspadorlegislativo/spiders/camara.py
@@ -52,6 +52,7 @@ class CamaraSpider(Spider):
             'id_site': bill.get('id'),
             'apresentacao': bill.get('dataApresentacao')[:10],  # 10 chars date
             'ementa': bill.get('ementa'),
+            'origem': 'CA',
             'url': self.urls['human'].format(bill.get('id')),
             'pending_requests': [
                 PendingRequest(

--- a/raspadorlegislativo/spiders/senado.py
+++ b/raspadorlegislativo/spiders/senado.py
@@ -51,6 +51,7 @@ class SenadoSpider(Spider):
             'ementa': description,
             'autoria': response.xpath('//NomeAutor/text()').extract_first(),
             'local': response.xpath('//NomeLocal/text()').extract_first(),
+            'origem': 'SE',
             'url': self.urls['humans'].format(code),
             'pending_requests': [
                 PendingRequest(

--- a/raspadorlegislativo/tests/test_raspador_pipeline.py
+++ b/raspadorlegislativo/tests/test_raspador_pipeline.py
@@ -1,0 +1,41 @@
+from unittest.mock import Mock
+
+from raspadorlegislativo import settings
+from raspadorlegislativo.items import Bill
+from raspadorlegislativo.pipelines import RaspadorlegislativoPipeline
+
+
+pipeline = RaspadorlegislativoPipeline()
+
+item = Bill(
+    nome='PL 3.1415',
+    id_site='31415',
+    apresentacao='2018-01-01',
+    ementa='Foobar',
+    autoria='Fulana de Tal',
+    local='Câmara',
+    origem='CA',
+    url='https://foob.ar/',
+    match={'key', 'word'}
+)
+
+serialized = {
+    'nome': 'PL 3.1415',
+    'id_site': '31415',
+    'apresentacao': '2018-01-01',
+    'ementa': 'Foobar',
+    'autoria': 'Fulana de Tal',
+    'local': 'Câmara',
+    'origem': 'CA',
+    'token': settings.RASPADOR_API_TOKEN
+}
+
+
+def test_serialize(mocker):
+    assert serialized == pipeline.serialize(item)
+
+
+def test_process_item(mocker):
+    post = mocker.patch('raspadorlegislativo.pipelines.post')
+    pipeline.process_item(item, Mock())
+    post.assert_called_once_with(settings.RASPADOR_API_URL, data=serialized)


### PR DESCRIPTION
Cria uma API para envio de informações de projetos de lei para o Radar Legislativo, de acordo com [a API que receberá esses projetos de lei](https://gitlab.com/codingrights/radarlegislativo/merge_requests/13).

Essa nova funcionalidade depende de duas novas configurações:

* `RASPADOR_API_TOKEN`: uma chave de segurança para validar a entrada de dados no Radar (tem que ser configurada com o mesmo valor em ambos os projetos)
* `RASPADOR_API_URL`: a URL onde está a API que recebe os dados no site do Radar

Para testar, o que eu fiz foi:

1. No **Radar**, adicionar o `RASPADOR_API_TOKEN` ao meu `.env` com um valor aleatório
2. Ainda no `.env` do **Radar**, adicionar o `host.docker.internal` no `ALLOWED_HOSTS` (o meu está assim `ALLOWED_HOSTS=127.0.0.1,0.0.0.0,localhost,host.docker.internal`)
3. No **Raspador** configurar o mesmo `RASPADOR_API_TOKEN` que no **Radar**
4. Ainda no **Raspador** configurar `RASPADOR_API_URL` para `http://host.docker.internal:8000/api/projeto/novo/`
5. Iniciar o **Radar** com `docker-compose -f docker-compose.dev.yml up`
6. Iniciar o **Raspador** com `docker-compose up`