### PR TITLE
Envia palavras-chave para a API do Radar

### DIFF
--- a/raspadorlegislativo/items.py
+++ b/raspadorlegislativo/items.py
@@ -9,6 +9,5 @@ class Bill(Item):
     autoria = Field()
     local = Field()
     origem = Field()
-
+    palavras_chave = Field()
     url = Field()
-    match = Field()

--- a/raspadorlegislativo/pipelines.py
+++ b/raspadorlegislativo/pipelines.py
@@ -10,8 +10,6 @@ log = logging.getLogger(__name__)
 
 class RaspadorlegislativoPipeline:
 
-    skip = {'match', 'url'}
-
     def process_item(self, item, spider):
         if all((settings.RASPADOR_API_TOKEN, settings.RASPADOR_API_URL)):
             self.post(item)
@@ -30,6 +28,7 @@ class RaspadorlegislativoPipeline:
             log.info(response.text)
 
     def serialize(self, item):
-        data = {k: v for k, v in dict(item).items() if k not in self.skip}
+        data = dict(item)
         data['token'] = settings.RASPADOR_API_TOKEN
+        data['palavras_chave'] = ', '.join(data['palavras_chave'])
         return data

--- a/raspadorlegislativo/spiders/__init__.py
+++ b/raspadorlegislativo/spiders/__init__.py
@@ -47,7 +47,7 @@ class Spider(OriginalSpider):
 
             data = self.get_bill(uuid)
 
-        if data['match']:
+        if data['palavras_chave']:
             data.pop('pending_requests')
             yield Bill(data)
 
@@ -60,7 +60,7 @@ class Spider(OriginalSpider):
         data = self.get_bill(uuid)
         for keyword in settings.KEYWORDS:
             if keyword in text:
-                data['match'].add(keyword)
+                data['palavras_chave'].add(keyword)
 
         os.remove(tmp)
         self.set_bill(uuid, data)

--- a/raspadorlegislativo/spiders/camara.py
+++ b/raspadorlegislativo/spiders/camara.py
@@ -47,7 +47,7 @@ class CamaraSpider(Spider):
         bill = json.loads(response.body_as_unicode()).get('dados', {})
         uuid = self.get_unique_id()
         data = {
-            'match': set(),  # later we include matching keywords in this list
+            'palavras_chave': set(),  # include matching keywords in this list
             'nome': '{} {}'.format(bill.get('siglaTipo'), bill.get('numero')),
             'id_site': bill.get('id'),
             'apresentacao': bill.get('dataApresentacao')[:10],  # 10 chars date
@@ -76,7 +76,7 @@ class CamaraSpider(Spider):
         summary = ' '.join((data['ementa'], bill.get('keywords')))
         for keyword in settings.KEYWORDS:
             if keyword in summary.lower():
-                data['match'].add(keyword)
+                data['palavras_chave'].add(keyword)
 
         self.set_bill(uuid, data)
         yield from self.process_pending_requests(uuid)

--- a/raspadorlegislativo/spiders/senado.py
+++ b/raspadorlegislativo/spiders/senado.py
@@ -44,7 +44,7 @@ class SenadoSpider(Spider):
 
         uuid = self.get_unique_id()
         data = {
-            'match': set(),  # later we include matching keywords in this list
+            'palavras_chave': set(),  # include matching keywords in this list
             'nome': f'{subject} {number}',
             'id_site': response.xpath('//CodigoMateria/text()').extract_first(),
             'apresentacao': response.xpath('//DataApresentacao/text()').extract_first(),
@@ -65,7 +65,7 @@ class SenadoSpider(Spider):
         summary = ' '.join((description, keywords))
         for keyword in settings.KEYWORDS:
             if keyword in summary.lower():
-                data['match'].add(keyword)
+                data['palavras_chave'].add(keyword)
 
         import logging
         log = logging.getLogger(__name__)

--- a/raspadorlegislativo/tests/test_raspador_pipeline.py
+++ b/raspadorlegislativo/tests/test_raspador_pipeline.py
@@ -16,7 +16,7 @@ item = Bill(
     local='Câmara',
     origem='CA',
     url='https://foob.ar/',
-    palavras_chave={'key', 'word'}
+    palavras_chave=('key', 'word')
 )
 
 serialized = {

--- a/raspadorlegislativo/tests/test_raspador_pipeline.py
+++ b/raspadorlegislativo/tests/test_raspador_pipeline.py
@@ -16,7 +16,7 @@ item = Bill(
     local='Câmara',
     origem='CA',
     url='https://foob.ar/',
-    match={'key', 'word'}
+    palavras_chave={'key', 'word'}
 )
 
 serialized = {
@@ -27,6 +27,8 @@ serialized = {
     'autoria': 'Fulana de Tal',
     'local': 'Câmara',
     'origem': 'CA',
+    'url': 'https://foob.ar/',
+    'palavras_chave': 'key, word',
     'token': settings.RASPADOR_API_TOKEN
 }
 


### PR DESCRIPTION
Envia o campo `palavras_chave` para o Radar. Isso permite que o Radar categorize automaticamente os PLs sugeridos pelo Raspador.