### PR TITLE
Usar diretório secrets do Radar para pegar palavras-chave

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,4 +3,4 @@ RASPADOR_API_URL=http://localhost:8000/api/
 RASPADOR_API_TOKEN=chave-da-api
 
 START_DATE=2015-01-01
-KEYWORDS=acesso, gênero, liberdade de expressão, privacidade, inovação, direito do consumidor
+KEYWORDS=/mnt/secrets/keywords.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 .env
-.scrapy/
 .pytest_cache/
+.scrapy/
 __pycache__/
 data/*.csv
+secrets/*.*
+!secrets/*.sample

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Repositório de testes de código para integrar, futuramente, o [Radar Legislati
 
 ## Configurações
 
-Copie o arquivo de configuração e edite-o de acordo com o desejado:
+Copie os arquivos de configuração e edite-os de acordo com o desejado:
 
 ```sh
 $ cp .env.sample .env
+$ cp secrets/keywords.json.sample secrets/keywords.json
 ```
 
 ## Instalação em container (com Docker)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - .env
     volumes:
       - ./:/code
+      - ./secrets:/mnt/secrets
     depends_on:
       - memcached
     command: ["scrapy", "crawl", "camara"]

--- a/raspadorlegislativo/settings.py
+++ b/raspadorlegislativo/settings.py
@@ -1,6 +1,6 @@
 from decouple import config
 
-from raspadorlegislativo.utils.decouple import Keyword
+from raspadorlegislativo.utils.decouple import keyword_parser
 
 # Scrapy settings for raspadorlegislativo project
 #
@@ -92,7 +92,7 @@ HTTPCACHE_STORAGE = 'scrapy_memcached_cache.MemcachedCacheStorage'
 MEMCACHED_LOCATION = config('MEMCACHED_LOCATION')
 
 # Settings for Scrapy to filter and save bills
-KEYWORDS = config('KEYWORDS', cast=Keyword())
+KEYWORDS = config('KEYWORDS', cast=keyword_parser)
 START_DATE = config('START_DATE')
 FEED_FORMAT = 'csv'
 

--- a/raspadorlegislativo/tests/test_keyword_parser.py
+++ b/raspadorlegislativo/tests/test_keyword_parser.py
@@ -1,0 +1,20 @@
+from json import dump
+from os import remove
+from tempfile import mkstemp
+
+from raspadorlegislativo.utils.decouple import keyword_parser
+
+
+def test_keyword_parser():
+    data = {
+        'tag1': ('keyword1', 'keyword2'),
+        'tag2': ('keyword3', 'keyword4', 'keyword5')
+    }
+
+    _, tmp = mkstemp(suffix='.json')
+    with open(tmp, 'w') as fobj:
+        dump(data, fobj)
+
+    expected = set(f'keyword{num}' for num in range(1, 6))
+    assert keyword_parser(tmp) == expected
+    remove(tmp)

--- a/raspadorlegislativo/utils/decouple.py
+++ b/raspadorlegislativo/utils/decouple.py
@@ -1,11 +1,12 @@
-from decouple import Csv
+import os
+from json import load
 
 
-class Keyword(Csv):
+def keyword_parser(path):
+    if not path or not os.path.exists(path):
+        return set()
 
-    def __init__(self, *args, **kwargs):
-        kwargs['post_process'] = set
-        super(Keyword, self).__init__(*args, **kwargs)
+    with open(path) as fobj:
+        data = load(fobj)
 
-    def __call__(self, value):
-        return super(Keyword, self).__call__(value.lower())
+    return set(keyword for keywords in data.values() for keyword in keywords)

--- a/secrets/keywords.json.sample
+++ b/secrets/keywords.json.sample
@@ -1,0 +1,4 @@
+{
+  "categoria": ["palavras_chave", "00000", "00.000", "Pena"],
+  "categoria 2": ["outras palavras chave", "9999", "9.999", "processo"]
+}


### PR DESCRIPTION
Ao invés do `KEYWORDS` no `.env` ou variável de ambiente ser uma lista de palavras, agora o Raspador utiliza o mesmo arquivo JSON  que o Radar.