### PR TITLE
Conserta o período de extração da spider do senado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 .env
-.idea/
 .pytest_cache/
 .scrapy/
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .env
+.idea/
 .pytest_cache/
 .scrapy/
 __pycache__/

--- a/raspadorlegislativo/spiders/senado.py
+++ b/raspadorlegislativo/spiders/senado.py
@@ -30,15 +30,15 @@ class SenadoSpider(BillSpider):
     }
 
     @staticmethod
-    def date_parameters(start_date):
-        formatted_start_date = start_date.isoformat().replace('-', '')
-        return [formatted_start_date] + [f"{year}0101" for year in range(start_date.year + 1, date.today().year + 1)]
+    def date_parameters(start_date_str):
+        yield start_date_str.replace('-', '')
+        start_date = date.fromisoformat(start_date_str)
+        yield from (f'{year}0101' for year in range(start_date.year + 1, date.today().year + 1))
 
     def start_requests(self):
-        for date_parameter in self.date_parameters(date.fromisoformat(settings.START_DATE)):
-            for subject in self.subjects:
-                url = self.urls['list'].format(subject, date_parameter)
-                yield Request(url=url)
+        for date_parameter in self.date_parameters(settings.START_DATE):
+            url = self.urls['list']
+            yield from (Request(url=url.format(subject, date_parameter)) for subject in self.subjects)
 
     def parse(self, response):
         """Parser para página que lista todos os PLS."""

--- a/raspadorlegislativo/spiders/senado.py
+++ b/raspadorlegislativo/spiders/senado.py
@@ -29,11 +29,16 @@ class SenadoSpider(BillSpider):
         )
     }
 
+    @staticmethod
+    def date_parameters(start_date):
+        formatted_start_date = start_date.isoformat().replace('-', '')
+        return [formatted_start_date] + [f"{year}0101" for year in range(start_date.year + 1, date.today().year + 1)]
+
     def start_requests(self):
-        for subject in self.subjects:
-            start_date = settings.START_DATE.replace('-', '')
-            url = self.urls['list'].format(subject, start_date)
-            yield Request(url=url)
+        for date_parameter in self.date_parameters(date.fromisoformat(settings.START_DATE)):
+            for subject in self.subjects:
+                url = self.urls['list'].format(subject, date_parameter)
+                yield Request(url=url)
 
     def parse(self, response):
         """Parser para página que lista todos os PLS."""

--- a/raspadorlegislativo/spiders/senado.py
+++ b/raspadorlegislativo/spiders/senado.py
@@ -33,7 +33,7 @@ class SenadoSpider(BillSpider):
     def date_parameters(start_date_str):
         yield start_date_str.replace('-', '')
         start_date = date.fromisoformat(start_date_str)
-        yield from (f'{year}0101' for year in range(start_date.year + 1, date.today().year + 1))
+        yield from (date(year, 1, 1).strftime("%Y%m%d") for year in range(start_date.year + 1, date.today().year + 1))
 
     def start_requests(self):
         for date_parameter in self.date_parameters(settings.START_DATE):


### PR DESCRIPTION
A versão atual da spider do senado só extrai os dados do ano configurado em `START_DATE` no `.env`. Essa PR conserta isso criando uma request para cada ano, a partir do `START_DATE` até a data atual.

