### PR TITLE
Atualiza spider do senado para novo endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .env
+.idea/
 .pytest_cache/
 .scrapy/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sobre **todos** os projetos de lei em tramitação desde `START_DATE`, mas
 nesse caso o _Raspador_ **não** envia os resultados para a API do
 _Radar Legislativo_.
 
-**Obs**: A spider do senado coleta dados a partir do ano em `START_DATE`,
+**Obs**: A _spider_ do Senado Federal coleta dados a partir do ano em `START_DATE`,
 não considerando o mês e o dia.
 
 ### Enviando os dados para o _Radar Legislativo_

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ sobre **todos** os projetos de lei em tramitação desde `START_DATE`, mas
 nesse caso o _Raspador_ **não** envia os resultados para a API do
 _Radar Legislativo_.
 
+**Obs**: A spider do senado coleta dados a partir do ano em `START_DATE`,
+não considerando o mês e o dia.
+
 ### Enviando os dados para o _Radar Legislativo_
 
 Configurando as variáveis `RASPADOR_API_URL` e `RASPADOR_API_TOKEN` de acordo

--- a/raspadorlegislativo/spiders/senado.py
+++ b/raspadorlegislativo/spiders/senado.py
@@ -29,11 +29,16 @@ class SenadoSpider(BillSpider):
         )
     }
 
+    @staticmethod
+    def date_parameters(start_date):
+        formatted_start_date = start_date.isoformat().replace('-', '')
+        return [formatted_start_date] + [f"{year}0101" for year in range(start_date.year + 1, date.today().year + 1)]
+
     def start_requests(self):
-        for subject in self.subjects:
-            start_date = settings.START_DATE.replace('-', '')
-            url = self.urls['list'].format(subject, start_date)
-            yield Request(url=url)
+        for date_parameter in self.date_parameters(date.fromisoformat(settings.START_DATE)):
+            for subject in self.subjects:
+                url = self.urls['list'].format(subject, date_parameter)
+                yield Request(url=url)
 
     def parse(self, response):
         """Parser para página que lista todos os PLS."""


### PR DESCRIPTION
O endpoint usado na spider do senado não está mais documentado. Essa PR atualiza a spider do senado para usar o novo endpoint `materia/tramitando` conforme documentado [aqui](https://legis.senado.leg.br/dadosabertos/docs/resource_MateriaService.html#resource_MateriaService_listaMateriasTramitando_GET).

Essa PR resolve a issue https://github.com/okfn-brasil/perfil-politico/issues/184

**Obs**: O csv gerado por esse endpoint foi comparado com o csv do endpoint anterior e o resultado é o mesmo.